### PR TITLE
Dodaj konfigurację Claude Code i komendy niestandardowe

### DIFF
--- a/.claude.json
+++ b/.claude.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "Context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp@latest"]
+    }
+  }
+}

--- a/.claude/commands/5-fetch-newsletter.md
+++ b/.claude/commands/5-fetch-newsletter.md
@@ -1,0 +1,7 @@
+Pod adresem <FEED_URL>https://przeprogramowani.substack.com/feed</FEED_URL> znajduje się RSS feed z newsletterami Przeprogramowanych hostowanych na Substack.
+
+Wykonaj następujące polecenia:
+
+1. Pobierz cały RSS feed i zapisz do tymczasowego pliku (np. `/tmp/newsletter.xml`).
+2. Wyszukaj najnowszy wpis (`item[0]`) i wczytaj do kontekstu rozmowy.
+3. Zapisz jego streszczenie w pliku newsletter.md

--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -1,0 +1,56 @@
+# Comprehensive Code Quality Review
+
+Perform comprehensive code quality review
+
+## Instructions
+
+Follow these steps to conduct a thorough code review:
+
+1. **Repository Analysis**
+   - Examine the repository structure and identify the primary language/framework
+   - Check for configuration files (package.json, requirements.txt, Cargo.toml, etc.)
+   - Review README and documentation for context
+
+2. **Code Quality Assessment**
+   - Scan for code smells, anti-patterns, and potential bugs
+   - Check for consistent coding style and naming conventions
+   - Identify unused imports, variables, or dead code
+   - Review error handling and logging practices
+
+3. **Security Review**
+   - Look for common security vulnerabilities (SQL injection, XSS, etc.)
+   - Check for hardcoded secrets, API keys, or passwords
+   - Review authentication and authorization logic
+   - Examine input validation and sanitization
+
+4. **Performance Analysis**
+   - Identify potential performance bottlenecks
+   - Check for inefficient algorithms or database queries
+   - Review memory usage patterns and potential leaks
+   - Analyze bundle size and optimization opportunities
+
+5. **Architecture & Design**
+   - Evaluate code organization and separation of concerns
+   - Check for proper abstraction and modularity
+   - Review dependency management and coupling
+   - Assess scalability and maintainability
+
+6. **Testing Coverage**
+   - Check existing test coverage and quality
+   - Identify areas lacking proper testing
+   - Review test structure and organization
+   - Suggest additional test scenarios
+
+7. **Documentation Review**
+   - Evaluate code comments and inline documentation
+   - Check API documentation completeness
+   - Review README and setup instructions
+   - Identify areas needing better documentation
+
+8. **Recommendations**
+   - Prioritize issues by severity (critical, high, medium, low)
+   - Provide specific, actionable recommendations
+   - Suggest tools and practices for improvement
+   - Create a summary report with next steps
+
+Remember to be constructive and provide specific examples with file paths and line numbers where applicable.

--- a/.claude/commands/rick_and_morty.md
+++ b/.claude/commands/rick_and_morty.md
@@ -1,0 +1,16 @@
+/rick-and-morty characterId: {characterId}, locationId: {locationId}
+
+Instrukcja dla Agenta:
+1. Wywołaj publiczne API Rick and Morty:
+   - Pobierz dane postaci z endpointu:
+     GET https://rickandmortyapi.com/api/character/{characterId}
+   - Pobierz dane lokalizacji z endpointu:
+     GET https://rickandmortyapi.com/api/location/{locationId}
+
+2. Na podstawie uzyskanych danych (imię, status, gatunek, obrazek postaci oraz nazwa i typ lokalizacji), wygeneruj krótką opowieść w 3 akapitach:
+   - Akapit 1: przedstaw postać i opisz jej charakter (na bazie danych z API).
+   - Akapit 2: osadź postać w wybranej lokalizacji (jej nazwa i typ).
+   - Akapit 3: opisz krótką interakcję lub przygodę bohatera w tej lokalizacji.
+
+3. Styl narracji: kreatywny, fabularny, z lekkim humorem pasującym do klimatu "Rick and Morty".
+4. Nie powtarzaj surowych danych API wprost – wpleć je w naturalną narrację.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,43 @@
+{
+  "permissions": {
+    "defaultMode": "acceptEdits",
+    "allow": [
+      "Edit(src/**)",
+      "Edit(tests/**)",
+      "Edit(*.py)",
+      "Write(src/**)",
+      "Write(tests/**)",
+      "Bash(pytest:*)",
+      "Bash(python -m pytest:*)",
+      "Bash(python -m unittest:*)",
+      "Bash(coverage run:*)",
+      "Bash(coverage report:*)",
+      "Bash(pylint:*)",
+      "Bash(flake8:*)",
+      "Bash(black:*)",
+      "Bash(mypy:*)",
+      "Bash(ruff:*)",
+      "Bash(pip install:*)",
+      "Bash(pip list)",
+      "Bash(python -m venv:*)",
+      "Bash(git commit:*)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:pypi.org)"
+    ],
+    "ask": [
+      "Bash(git push:*)",
+      "Bash(pip uninstall:*)",
+      "Bash(rm -rf:*)"
+    ],
+    "deny": [
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(./secrets/**)",
+      "Read(./**/*secret*)",
+      "Read(./**/*password*)",
+      "Read(./**/*token*)",
+      "Read(./config/credentials*)"
+    ],
+    "additionalDirectories": ["../docs/"]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,102 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+This is a warmup repository for the 10xDevs.pl training program. It contains TypeScript exercises focused on TDD practices, AI-assisted development workflows, and specification-driven implementation. The primary exercise is a banking system implementation in `banking/` with full test coverage.
+
+## Commands
+
+### Installation
+```bash
+npm install
+```
+
+### Testing
+```bash
+# Run all tests
+npm test
+
+# Run tests in watch mode
+npx vitest --watch
+
+# Run a specific test file
+npx vitest banking/banking.test.ts
+```
+
+## Project Structure
+
+The repository is organized into domain-specific modules with accompanying specifications and tests:
+
+- **`banking/`** - Core banking system exercise
+  - `banking.ts` - Domain logic implementation
+  - `types.ts` - TypeScript interfaces and types
+  - `banking.test.ts` - Vitest test suite
+  - `banking-spec.md` - Functional requirements specification (in Polish)
+  - `prompts/` - AI prompts for analysis and implementation guidance
+
+- **`prompts/`** - Reusable AI prompts for different scenarios
+  - `decomposer.md` / `decomposer_pl.md` - Task decomposition prompts
+  - `unblocker.md` / `unblocker_pl.md` - Problem-solving prompts
+
+- **`charts/`** - Mermaid diagram exercises
+  - `request.md` - Diagram creation tasks
+
+## Architecture & Patterns
+
+### Testing Architecture
+- **Framework**: Vitest 3.0.9
+- **Pattern**: Specification-driven TDD - tests are derived from `banking-spec.md`
+- **Structure**: Nested `describe`/`it` blocks mirroring business rules
+- **Coverage**: Both happy paths and error cases with explicit error codes and messages
+
+### Type System
+- Strict TypeScript 5.8+ with `strict: true` in tsconfig
+- Domain types defined in `types.ts` using interfaces
+- Error handling via discriminated unions (`WithdrawalResult | WithdrawalError`)
+- Error codes: `INSUFFICIENT_FUNDS`, `INVALID_AMOUNT`, `ACCOUNT_NOT_FOUND`
+
+### Code Organization
+- Domain logic isolated in feature modules (`banking/`)
+- Supporting materials (specs, prompts) co-located with implementation
+- Pure functions preferred with `const` declarations
+- Transaction IDs generated using timestamp + random string pattern
+
+## Coding Standards
+
+From `CONVENTIONS.md` and `.github/copilot-instructions.md`:
+- TypeScript 5.7+ with strict mode enabled
+- Prefer `const` over `let` and `var`
+- Avoid `any` type
+- Two-space indentation with trailing commas
+- Double-quoted imports
+- PascalCase for types (`WithdrawalRequest`)
+- camelCase for functions (`processWithdrawal`)
+
+## Key Development Workflows
+
+### Implementing New Features
+1. Check `banking-spec.md` for functional requirements
+2. Review or add corresponding test cases in `banking.test.ts`
+3. Implement logic in `banking.ts` to satisfy tests
+4. Ensure error handling returns proper error codes and messages
+
+### Working with Tests
+- Tests define the contract - implementation must match test expectations
+- Error cases must return objects with `code` and `message` properties
+- Success cases must return `success: true` with transaction details
+- Use `npx vitest --watch` during development
+
+### AI Collaboration Patterns
+The `prompts/` directory contains structured prompts for:
+- Breaking down complex problems into LLM-friendly steps
+- Analyzing specifications and generating implementation plans
+- Both English and Polish variants available
+
+## Important Notes
+
+- The repository includes Cursor commands in `.cursor/commands/` for various tasks
+- Cursor rules in `.cursor/rules/hooks.mdc` define React Hooks compliance rules (for reference, not directly applicable to current banking exercise)
+- Follow Conventional Commits pattern: `feat:`, `chore:`, `fix:`, etc.
+- New test files should be named `<feature>.test.ts` beside the code they verify


### PR DESCRIPTION
## Podsumowanie

Dodano konfigurację Claude Code wraz z zestawem niestandardowych komend do automatyzacji przepływów pracy w projekcie.

## Zmiany

- **Konfiguracja Claude Code** (`.claude/settings.json`)
  - Ustawienia uprawnień z domyślnym trybem `acceptEdits`
  - Lista dozwolonych operacji: edycja plików źródłowych, uruchamianie testów, instalacja pakietów
  - Ograniczenia dostępu do plików wrażliwych (.env, secrets, credentials)
  - Dodatkowy katalog dokumentacji w uprawnieniach

- **Komendy niestandardowe**
  - `code-review.md` - kompleksowy przegląd jakości kodu (analiza struktury, bezpieczeństwo, wydajność, architektura, testy, dokumentacja)
  - `5-fetch-newsletter.md` - pobieranie i streszczanie najnowszego wpisu z RSS feed Przeprogramowanych
  - `rick_and_morty.md` - komenda do integracji z Rick and Morty API

## Szczegóły techniczne

### Uprawnienia
- Automatyczna akceptacja edycji dla plików w `src/` i `tests/`
- Dozwolone komendy testowe: pytest, unittest, coverage
- Dozwolone narzędzia quality: pylint, flake8, black, mypy, ruff
- Wymagane potwierdzenie dla: git push, pip uninstall, rm -rf

### Zabezpieczenia
Zablokowany dostęp do:
- Plików środowiskowych (.env)
- Katalogów z sekretami
- Plików zawierających hasła, tokeny, credentials

## Test plan

- [x] Commit utworzony pomyślnie
- [x] Zmiany wypchane na remote
- [ ] Pull request utworzony
- [ ] Code review przeszedł pomyślnie